### PR TITLE
correct-purchase-error

### DIFF
--- a/app/controllers/purchases_controller.rb
+++ b/app/controllers/purchases_controller.rb
@@ -1,26 +1,37 @@
 class PurchasesController < ApplicationController
   before_action :authenticate_user!, only: [:index, :create]
   before_action :set_item, only: [:index, :create]
+  before_action :check_item_purchased, only: [:index, :create]
 
   def index
-    redirect_to root_path if current_user.id == @item.user.id
-
-    @exist = Purchase.where(item_id: params[:item_id]).exists?
-    if @exist == true
-      redirect_to root_path
+    if @purchased_item == false
+      if current_user.id != @item.user.id
+        @purchase_item = PurchaseItem.new
+      else
+        redirect_to root_path
+      end
     else
-      @purchase_item = PurchaseItem.new
+      redirect_to root_path
     end
   end
 
   def create
-    @purchase_item = PurchaseItem.new(purchase_params)
-    if @purchase_item.valid?
-      purchase
-      @purchase_item.save
-      redirect_to root_path
+    if @purchased_item == false
+      if current_user.id != @item.user.id
+        @purchase_item = PurchaseItem.new(purchase_params)
+        if @purchase_item.valid?
+          purchase
+          @purchase_item.save
+          redirect_to root_path
+        else
+          render action: :index
+        end
+      else
+        redirect_to root_path
+      end
+
     else
-      render action: :index
+      redirect_to root_path
     end
   end
 
@@ -43,5 +54,9 @@ class PurchasesController < ApplicationController
 
   def set_item
     @item = Item.find(params[:item_id])
+  end
+
+  def check_item_purchased
+    @purchased_item = Purchase.where(item_id: @item.id).exists?
   end
 end

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -25,14 +25,12 @@
     </div>
 
     <% if user_signed_in? %>
-      <% if current_user.id == @item.user.id %>
-        <%= link_to "商品の編集", edit_item_path, method: :get, class: "item-red-btn" %>
-        <p class="or-text">or</p>
-        <%= link_to "削除", "/items/#{@item.id}}", method: :delete, class:"item-destroy" %>
-      <% else %>
-
-        <% @purchased_item = Purchase.where(item_id: @item.id).exists? %>
-        <% if @purchased_item == false %>
+      <% if @purchased_item == false %>
+        <% if current_user.id == @item.user.id %>
+          <%= link_to "商品の編集", edit_item_path, method: :get, class: "item-red-btn" %>
+          <p class="or-text">or</p>
+          <%= link_to "削除", "/items/#{@item.id}}", method: :delete, class:"item-destroy" %>
+        <% else %>
           <%= link_to "購入画面に進む", "/items/#{ @item.id }/purchases" ,class:"item-red-btn"%>
         <% end %>
       <% end %>


### PR DESCRIPTION
挙動確認結果を受けての修正
ログイン状態の出品者でも、売却済みの商品にも「編集・削除ボタン」が表示されてしまう
URLを直接入力して自身の出品した"売却済み"商品購入ページに遷移しようとすると、エラー画面に遷移する